### PR TITLE
[trivial] Fix the InterPlanetary File System (IPFS) url

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,7 +134,7 @@ Lastly, `did:btc` draws a distinction between the "wallet keys" used to sign bit
 
 ### `did:ion`
 
-[ION](https://github.com/decentralized-identity/ion) (`did:ion`) also uses the bitcoin blockchain for its decentralized identifiers. However, unlike `did:btc` what goes on chain is only a pointer to a document in IPFS, and resolving ION dids requires indexing all the data on [IPFS](https://www.ipfs.com/) that is pointed to by bitcoin transactions. While this does guarantee the ordering and integrity of DID operations on IPFS, it introduces a number of external dependencies besides the bitcoin blockchain.
+[ION](https://github.com/decentralized-identity/ion) (`did:ion`) also uses the bitcoin blockchain for its decentralized identifiers. However, unlike `did:btc` what goes on chain is only a pointer to a document in IPFS, and resolving ION dids requires indexing all the data on [IPFS](https://ipfs.tech/) that is pointed to by bitcoin transactions. While this does guarantee the ordering and integrity of DID operations on IPFS, it introduces a number of external dependencies besides the bitcoin blockchain.
 
 ### Non-bitcoin blockchain-based DID methods
 


### PR DESCRIPTION
Currently the InterPlanetary File System (IPFS) URL points to https://www.ipfs.com which obviously is incorrect since this is completely different project [1], correct url is https://ipfs.tech/, similar reference on ION's page [2]

Footnores
[1] One Platform for Premium Finance and Payments
https://github.com/decentralized-identity/ion/blob/master/install-guide.md#3-installing-kubo-ipfs [2] https://github.com/decentralized-identity/ion/blob/master/install-guide.md#3-installing-kubo-ipfs