### PR TITLE
Fixed wrong id in example 4

### DIFF
--- a/index.html
+++ b/index.html
@@ -343,12 +343,12 @@ Resolving a `did:btc` DID can be done using the following steps:
     "https://www.w3.org/ns/did/v1",
     "https://w3id.org/security/multikey/v1"
   ],
-  "id": "x20r-ayaz-qqtl-ljk",
+  "id": "did:btc:x20r-ayaz-qqtl-ljk",
   "controller": "did:key:z6DtNrvHVvvKHB7m8LrCmt131TGH7DbzvcPo9mZRoCt5rqms",
   "verificationMethod": [
     {
-      "id": "x20r-ayaz-qqtl-ljk#key-0",
-      "controller": "x20r-ayaz-qqtl-ljk",
+      "id": "did:btc:x20r-ayaz-qqtl-ljk#key-0",
+      "controller": "did:btc:x20r-ayaz-qqtl-ljk",
       "type": "Multikey",
       "publicKeyMultibase": "z6MkfNwZ7ncwr54BVWA9taEJLaHAWYEuqMNQfBzrwLEoaoVB"
     }


### PR DESCRIPTION
As mentioned in #5 , the id was missing the did:btc: URI prefix.