### PR TITLE
Added main entrypoint to package.json so imports resolve when package…

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,7 @@
 {
   "name": "did-btc-sdk",
   "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "version": "1.0.0",


### PR DESCRIPTION
…d for distribution

I also published this under npmjs.org at the following.

[did-btc-sdk](https://www.npmjs.com/package/did-btc-sdk)

I'm happy to remove it if you want to republish it as a scoped package @microstrategy/did-btc-sdk etc.

Also working on a self-sovereign reference implementation including wallet handling and lookup service. -Andrew andrew@lunde.com